### PR TITLE
Check if $ldapConfig['servers'] is set before using it

### DIFF
--- a/docs/cas.md
+++ b/docs/cas.md
@@ -91,7 +91,7 @@ and even some custom attributes if they're set:
 ```
 
 You'll probably want to avoid querying LDAP for attributes:
-set `ldap` to a null array (but `ldap` MUST be set):
+set `ldap` to a `null`:
 
 ```php
 'example-cas' => [
@@ -99,5 +99,5 @@ set `ldap` to a null array (but `ldap` MUST be set):
     'cas' => [
         ...
 ],
-'ldap' => [],
+'ldap' => null,
 ```

--- a/src/Auth/Source/CAS.php
+++ b/src/Auth/Source/CAS.php
@@ -213,7 +213,7 @@ class CAS extends Auth\Source
             $this->ldapConfig,
             'Authentication source ' . var_export($this->authId, true)
         );
-        if ($this->ldapConfig['servers']) {
+        if (isset($this->ldapConfig['servers']) && $this->ldapConfig['servers']) {
             $ldap = new Ldap(
                 $config->getString('servers'),
                 $config->getOptionalBoolean('enable_tls', false),

--- a/src/Auth/Source/CAS.php
+++ b/src/Auth/Source/CAS.php
@@ -213,7 +213,7 @@ class CAS extends Auth\Source
             $this->ldapConfig,
             'Authentication source ' . var_export($this->authId, true)
         );
-        if (isset($this->ldapConfig['servers']) && $this->ldapConfig['servers']) {
+        if (!empty($this->ldapConfig['servers'])) {
             $ldap = new Ldap(
                 $config->getString('servers'),
                 $config->getOptionalBoolean('enable_tls', false),


### PR DESCRIPTION
This fixes an "Undefined index: servers" notice in the typical use case
where you set the ldap config portion of the auth source to an empty
array to disable it.